### PR TITLE
Updated peer dependencies and applied fix in prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "handlebars": "4",
-    "i18next": "11"
+    "i18next": ">=11"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "*.js*"
   ],
   "scripts": {
-    "prepare": "babel --no-babelrc --presets @babel/preset-env --plugins @babel/plugin-transform-modules-umd handlebars-i18next.es6 -so handlebars-i18next.js"
+    "prepare": "babel --no-babelrc --presets @babel/preset-env --plugins @babel/plugin-transform-modules-umd handlebars-i18next.es6 -s true -o handlebars-i18next.js"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
@jgonggrijp we're using this helper in one of our projects. While not a big deal, we're getting a warning about a missing peer dependency for i18next. This is because we're using the most recent version v21.6.11 and this helper requires it to be one of version v4 (dating back to 2017). 

Warning:

```
npm WARN handlebars-i18next@1.0.1 requires a peer of i18next@11 but none is installed. You must install peer dependencies yourself.
```

As far as I can tell the latest version of i18next is still compatible.

I also set the sourceMaps (`-s` option) explicitly to `true` as it was giving me errors (not sure why this is suddenly required though).