### PR TITLE
Include npm badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # handlebars-i18next
 
+![npm](https://img.shields.io/npm/dt/handlebars-i18next) [![npm version](https://badge.fury.io/js/handlebars-i18next.svg)](https://badge.fury.io/js/handlebars-i18next)
+
 [Handlebars][1] helper that lets you translate with [i18next][2] inside your templates.
 
 [1]: https://handlebarsjs.com

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # handlebars-i18next
 
-![npm](https://img.shields.io/npm/dt/handlebars-i18next) [![npm version](https://badge.fury.io/js/handlebars-i18next.svg)](https://badge.fury.io/js/handlebars-i18next)
+[![npm](https://img.shields.io/npm/dt/handlebars-i18next)](https://badge.fury.io/js/handlebars-i18next) [![npm version](https://badge.fury.io/js/handlebars-i18next.svg)](https://badge.fury.io/js/handlebars-i18next)
 
 [Handlebars][1] helper that lets you translate with [i18next][2] inside your templates.
 


### PR DESCRIPTION
This PR includes the npm registry and number of downloads as badges. Adding the badges helps with visibility of the package and therefore increase traffic.